### PR TITLE
feat: soure map url

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "test": "deno test --doc --jobs --shuffle --allow-net --allow-read=.",
+    "test": "deno test --doc --parallel --shuffle --allow-net --allow-read=.",
     "check": "deno check ./mod.ts"
   },
   "importMap": "./import-map.json"

--- a/file_server_test.ts
+++ b/file_server_test.ts
@@ -1,6 +1,11 @@
 import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { serve } from "https://deno.land/std@0.151.0/http/mod.ts";
-import { serveDirWithTs, serveFileWithTs, transpile } from "./mod.ts";
+import {
+  MediaType,
+  serveDirWithTs,
+  serveFileWithTs,
+  transpile,
+} from "./mod.ts";
 
 Deno.test({
   name: "file server - serveFileWithTs",
@@ -87,6 +92,31 @@ Deno.test({
     assertEquals(
       res.headers.get("Content-Type"),
       "text/markdown; charset=UTF-8",
+    );
+  },
+});
+
+Deno.test({
+  name: "file server - serveFileWithTs (invalid url)",
+  async fn() {
+    const request = new Request("http://localhost/");
+    Object.defineProperty(request, "url", {
+      value: "http://",
+    });
+    // Determine file type from file path and don't give error
+    const res = await serveFileWithTs(request, "./mod.ts");
+    assertEquals(
+      await res.text(),
+      await transpile(
+        await Deno.readTextFile(new URL("./mod.ts", import.meta.url)),
+        new URL("file:///src"),
+        MediaType.TypeScript,
+      ),
+    );
+    assertEquals(res.status, 200);
+    assertEquals(
+      res.headers.get("Content-Type"),
+      "application/javascript; charset=UTF-8",
     );
   },
 });

--- a/file_server_test.ts
+++ b/file_server_test.ts
@@ -31,7 +31,7 @@ Deno.test({
         await res.text(),
         await transpile(
           await Deno.readTextFile(new URL("./mod.ts", import.meta.url)),
-          new URL("file:///src.ts"),
+          new URL("http://localhost:8886/mod.ts"),
         ),
       );
       assertEquals(
@@ -45,7 +45,7 @@ Deno.test({
         await res.text(),
         await transpile(
           await Deno.readTextFile(new URL("./test/a.tsx", import.meta.url)),
-          new URL("file:///src.tsx"),
+          new URL("http://localhost:8886/test/a.tsx"),
         ),
       );
       assertEquals(
@@ -59,7 +59,7 @@ Deno.test({
         await res.text(),
         await transpile(
           await Deno.readTextFile(new URL("./test/a.jsx", import.meta.url)),
-          new URL("file:///src.jsx"),
+          new URL("http://localhost:8886/test/a.jsx"),
         ),
       );
       assertEquals(
@@ -110,7 +110,7 @@ Deno.test({
         await res.text(),
         await transpile(
           await Deno.readTextFile(new URL("./mod.ts", import.meta.url)),
-          new URL("file:///src.ts"),
+          new URL("http://localhost:8887/mod.ts"),
         ),
       );
       assertEquals(
@@ -124,7 +124,7 @@ Deno.test({
         await res.text(),
         await transpile(
           await Deno.readTextFile(new URL("./test/a.tsx", import.meta.url)),
-          new URL("file:///src.tsx"),
+          new URL("http://localhost:8887/test/a.tsx"),
         ),
       );
       assertEquals(
@@ -138,7 +138,7 @@ Deno.test({
         await res.text(),
         await transpile(
           await Deno.readTextFile(new URL("./test/a.jsx", import.meta.url)),
-          new URL("file:///src.jsx"),
+          new URL("http://localhost:8887/test/a.jsx"),
         ),
       );
       assertEquals(
@@ -198,7 +198,7 @@ Deno.test({
       await res.text(),
       await transpile(
         await Deno.readTextFile(new URL("./mod.ts", import.meta.url)),
-        new URL("file:///src.ts"),
+        new URL("file:///mod.ts"),
       ),
     );
     assertEquals(

--- a/mod.ts
+++ b/mod.ts
@@ -38,16 +38,16 @@ export async function serveFileWithTs(
   try {
     url = new URL(request.url, "file:///");
   } catch {
-    return response;
+    url = new URL("file:///src");
   }
   // if range request, skip
   if (response.status === 200) {
     if (filePath.endsWith(".ts")) {
-      return rewriteTsResponse(response, url);
+      return rewriteTsResponse(response, url, MediaType.TypeScript);
     } else if (filePath.endsWith(".tsx")) {
-      return rewriteTsResponse(response, url);
+      return rewriteTsResponse(response, url, MediaType.Tsx);
     } else if (filePath.endsWith(".jsx")) {
-      return rewriteTsResponse(response, url);
+      return rewriteTsResponse(response, url, MediaType.Jsx);
     }
   }
   return response;
@@ -88,9 +88,13 @@ export async function serveDirWithTs(
   return response;
 }
 
-async function rewriteTsResponse(response: Response, url: URL) {
+async function rewriteTsResponse(
+  response: Response,
+  url: URL,
+  mediaType?: MediaType,
+) {
   const tsCode = await response.text();
-  const jsCode = await transpile(tsCode, url);
+  const jsCode = await transpile(tsCode, url, mediaType);
   const { headers } = response;
   headers.set("content-type", jsContentType);
   headers.delete("content-length");

--- a/oak_test.ts
+++ b/oak_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { deferred } from "https://deno.land/std@0.151.0/async/mod.ts";
 import { Application } from "https://deno.land/x/oak@v10.6.0/mod.ts";
-import { transpile, tsMiddleware } from "./mod.ts";
+import { MediaType, transpile, tsMiddleware } from "./mod.ts";
 
 const port = 8888;
 const jsContentType = "application/javascript; charset=utf-8";
@@ -41,11 +41,7 @@ async function readTextFile(path: string) {
   return await Deno.readTextFile(new URL(path, import.meta.url));
 }
 async function transpileFile(path: string) {
-  const url = path.endsWith(".ts")
-    ? new URL("file:///src.ts")
-    : path.endsWith(".tsx")
-    ? new URL("file:///src.tsx")
-    : new URL("file:///src.jsx");
+  const url = new URL(path, `http://localhost:${port}`);
   return await transpile(await readTextFile(path), url);
 }
 
@@ -125,7 +121,7 @@ Deno.test({
     const res = await app.handle(new Request("http://localhost/"));
     assertEquals(
       await res!.text(),
-      await transpile(code, new URL("file:///src.ts")),
+      await transpile(code, new URL("http://localhost/"), MediaType.TypeScript),
     );
   },
 });
@@ -143,7 +139,7 @@ Deno.test({
     const res = await app.handle(new Request("http://localhost/"));
     assertEquals(
       await res!.text(),
-      await transpile(code, new URL("file:///src.ts")),
+      await transpile(code, new URL("http://localhost/"), MediaType.TypeScript),
     );
   },
 });
@@ -161,7 +157,7 @@ Deno.test({
     const res = await app.handle(new Request("http://localhost/"));
     assertEquals(
       await res!.text(),
-      await transpile(code, new URL("file:///src.ts")),
+      await transpile(code, new URL("http://localhost/"), MediaType.TypeScript),
     );
   },
 });

--- a/utils/transpile.ts
+++ b/utils/transpile.ts
@@ -7,6 +7,7 @@ export enum MediaType {
   Tsx,
 }
 
+// https://github.com/denoland/deno_ast/blob/ea1ccec37e1aa8e5e1e70f983a7ed1472d0e132a/src/media_type.rs#L117
 const contentType = {
   [MediaType.TypeScript]: "text/typescript; charset=utf-8",
   [MediaType.Jsx]: "text/jsx; charset=utf-8",

--- a/utils/transpile.ts
+++ b/utils/transpile.ts
@@ -1,5 +1,6 @@
 import { emit } from "https://deno.land/x/emit@0.4.0/mod.ts";
 
+/** File type. You can pass it as an option to the transpile function to tell it what media type the source is. */
 export enum MediaType {
   TypeScript,
   Jsx,
@@ -16,14 +17,16 @@ const contentType = {
  * Transpile the given TypeScript code into JavaScript code.
  *
  * @param content TypeScript code
- * @param specifier URL like `new URL("file:///src.ts")` or `new URL("file:///src.tsx")`
+ * @param specifier The URL that will be used for the source map.
+ * @param mediaType Indicates whether the source code is TypeScript, JSX or TSX. If this argument is not passed, the file type is guessed using the extension of the URL passed as the second argument.
  * @return JavaScript code
  *
  * ```ts
- * import { transpile } from "https://deno.land/x/ts_serve@$VERSION/mod.ts";
+ * import { transpile, MediaType } from "https://deno.land/x/ts_serve@$VERSION/mod.ts";
  * console.log(await transpile(
  *   "function name(params:type) {}",
- *   new URL("file:///src.ts")
+ *   new URL("file:///src.ts"),
+ *   MediaType.TypeScript,
  * ));
  * ```
  */

--- a/utils/transpile.ts
+++ b/utils/transpile.ts
@@ -1,5 +1,17 @@
 import { emit } from "https://deno.land/x/emit@0.4.0/mod.ts";
 
+export enum MediaType {
+  TypeScript,
+  Jsx,
+  Tsx,
+}
+
+const contentType = {
+  [MediaType.TypeScript]: "text/typescript; charset=utf-8",
+  [MediaType.Jsx]: "text/jsx; charset=utf-8",
+  [MediaType.Tsx]: "text/tsx; charset=utf-8",
+};
+
 /**
  * Transpile the given TypeScript code into JavaScript code.
  *
@@ -15,7 +27,11 @@ import { emit } from "https://deno.land/x/emit@0.4.0/mod.ts";
  * ));
  * ```
  */
-export async function transpile(content: string, specifier: URL) {
+export async function transpile(
+  content: string,
+  specifier: URL,
+  mediaType?: MediaType,
+) {
   const urlStr = specifier.toString();
   const result = await emit(specifier, {
     load(specifier) {
@@ -27,7 +43,16 @@ export async function transpile(content: string, specifier: URL) {
           headers: { "content-type": "application/javascript; charset=utf-8" },
         });
       }
-      return Promise.resolve({ kind: "module", specifier, content });
+      return Promise.resolve({
+        kind: "module",
+        specifier,
+        content,
+        headers: {
+          "content-type": mediaType != undefined
+            ? contentType[mediaType]
+            : undefined!,
+        },
+      });
     },
   });
   return result[urlStr];

--- a/utils/transpile_test.ts
+++ b/utils/transpile_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
-import { transpile } from "./transpile.ts";
+import { MediaType, transpile } from "./transpile.ts";
 
 const codes = [
   [
@@ -34,3 +34,18 @@ for (const [path, src, emit] of codes) {
     },
   });
 }
+
+Deno.test({
+  name: `transpile - with no extension`,
+  async fn() {
+    assertEquals(
+      await transpile(
+        "function name(params:type) {}",
+        new URL("https://foo.com/bar"),
+        MediaType.TypeScript,
+      ),
+      `function name(params) {}
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImh0dHBzOi8vZm9vLmNvbS9iYXIiXSwic291cmNlc0NvbnRlbnQiOlsiZnVuY3Rpb24gbmFtZShwYXJhbXM6dHlwZSkge30iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsU0FBUyxJQUFJLENBQUMsTUFBVyxFQUFFLEVBQUUifQ==`,
+    );
+  },
+});


### PR DESCRIPTION
Improve the URLs included in your source maps. Currently, it is uniformly "src.{ts,tsx,jsx}".

![image](https://user-images.githubusercontent.com/40050810/185755242-2cde1a9d-7c6d-4cd1-ae2a-c920a1c67fea.png)
